### PR TITLE
Vpn fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <name>Shibboleth IdP :: slack login interceptor</name>
     <artifactId>uw-slack-intercept</artifactId>
     <groupId>edu.washington.iam</groupId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/src/main/java/edu/washington/idp/intercept/impl/PasswordRecoveryIntercept.java
+++ b/src/main/java/edu/washington/idp/intercept/impl/PasswordRecoveryIntercept.java
@@ -237,6 +237,8 @@ public class PasswordRecoveryIntercept implements Predicate<ProfileRequestContex
                 return NO_WARNING;
             }
             if (targetEntityId == null || passwordEntityId.equals(targetEntityId)) {return NO_WARNING;}
+            //The VPN cannot handle the link to the identity site. Show no warning for those sites as well.
+            if (targetEntityId.contains("huskyonnet")) {return NO_WARNING;}
 
             // Get the username. If not available, this call will log an error and return null,
             // in which case we will not show a warning.


### PR DESCRIPTION
Added a minor check to the code to exclude the VPN sites from the warning. The browser used for those sites cannot handle the linked page, so any user clicking the link gets an error.